### PR TITLE
Update RCTC Spreadsheet deprecation notice for 1.5.3

### DIFF
--- a/apps/client/src/app/spec-download/spec-download.component.html
+++ b/apps/client/src/app/spec-download/spec-download.component.html
@@ -56,7 +56,7 @@
     <div class="alert alert-primary border-0 shadow-sm mb-4" role="alert">
       <h6 class="alert-heading fw-bold">Important Notice: RCTC Spreadsheet Deprecation</h6>
       <p>
-        The RCTC Spreadsheet will be deprecated and no longer available for implementing updates by late 2026. 
+        The RCTC Spreadsheet will be deprecated and no longer available for implementing updates by Q1, 2027.
         If your implementation currently relies on the spreadsheet format, we strongly recommend beginning the 
         transition to a FHIR-based implementation.
       </p>

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log: eRSD Release 1.5.3
 
+### UI/UX Updates
+- Updated RCTC Spreadsheet deprecation notice to state availability ends by Q1, 2027 (was late 2026)
+- Updated hidden site version value to eRSD Version: 1.5.3
+
 ### Security
 - Remediated ECR/Inspector findings for the kds-portal container image
 - Upgraded vulnerable runtime dependencies including axios, multer, dompurify, nodemailer, lodash/lodash-es, tmp, qs, uuid, mermaid, body-parser, and related transitive packages


### PR DESCRIPTION
## Summary
- Update the RCTC Spreadsheet deprecation notice to state availability ends by Q1, 2027 (was late 2026)
- Document the UI wording change and hidden site version 1.5.3 in the changelog

## Test plan
- [ ] Open the home/specification download page and confirm the Important Notice text reads “by Q1, 2027”
- [ ] Confirm the rest of the notice (heading and FHIR transition guidance) is unchanged
- [ ] Confirm changelog.md 1.5.3 section includes the new UI/UX Updates bullets


Made with [Cursor](https://cursor.com)