### PR TITLE
Update RCTC Spreadsheet deprecation notice to early 2027

### DIFF
--- a/apps/client/src/app/spec-download/spec-download.component.html
+++ b/apps/client/src/app/spec-download/spec-download.component.html
@@ -56,7 +56,7 @@
     <div class="alert alert-primary border-0 shadow-sm mb-4" role="alert">
       <h6 class="alert-heading fw-bold">Important Notice: RCTC Spreadsheet Deprecation</h6>
       <p>
-        The RCTC Spreadsheet will be deprecated and no longer available for implementing updates by Q1, 2027.
+        The RCTC Spreadsheet will be deprecated and no longer available for implementing updates by early 2027.
         If your implementation currently relies on the spreadsheet format, we strongly recommend beginning the 
         transition to a FHIR-based implementation.
       </p>

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Change Log: eRSD Release 1.5.3
 
 ### UI/UX Updates
-- Updated RCTC Spreadsheet deprecation notice to state availability ends by Q1, 2027 (was late 2026)
+- Updated RCTC Spreadsheet deprecation notice to state availability ends by early 2027 (was Q1, 2027; previously late 2026)
 - Updated hidden site version value to eRSD Version: 1.5.3
 
 ### Security


### PR DESCRIPTION
## Summary
- Update the RCTC Spreadsheet deprecation notice to state availability ends by early 2027 (was Q1, 2027)
- Reflect the wording change in the 1.5.3 changelog

## Test plan
- [ ] Open the specification download page and confirm the Important Notice reads “by early 2027”
- [ ] Confirm the rest of the notice is unchanged
- [ ] Confirm changelog.md UI/UX bullet matches


Made with [Cursor](https://cursor.com)